### PR TITLE
Enable babel for example module

### DIFF
--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karlhorky/react-server-cli",
-  "version": "0.5.1-experimental.1",
+  "version": "0.5.1-experimental.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karlhorky/react-server-cli",
-  "version": "0.5.1-alpha.3",
+  "version": "0.5.1-experimental.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react-server-cli/package.json
+++ b/packages/react-server-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karlhorky/react-server-cli",
-  "version": "0.5.1-experimental.0",
+  "version": "0.5.1-experimental.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -4,6 +4,6 @@ const cli = require(".");
 
 cli.parseCliArgs().then(args => {
   const config = args.rulesPath ? JSON.parse(fs.readFileSync(path.resolve(args.rulesPath + '/.babelrc'))) : {};
-  require("babel-core/register")(config);
+  require("babel-core/register")(Object.assign(config, { ignore: /node_modules\/(?!example-review-module)/ }));
   cli.run(args);
 }).catch(console.error);

--- a/packages/react-server-cli/src/cli.js
+++ b/packages/react-server-cli/src/cli.js
@@ -4,6 +4,6 @@ const cli = require(".");
 
 cli.parseCliArgs().then(args => {
   const config = args.rulesPath ? JSON.parse(fs.readFileSync(path.resolve(args.rulesPath + '/.babelrc'))) : {};
-  require("babel-core/register")(Object.assign(config, { ignore: /node_modules\/(?!example-review-module)/ }));
+  require("babel-core/register")(config);
   cli.run(args);
 }).catch(console.error);

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -150,6 +150,15 @@ function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, l
 					test: /\.jsx?$/,
 					loader: "babel",
 					exclude: /node_modules\/(?!example-review-module)/,
+					// FIXME: Read config from the .babelrc using the webpackConfig function in .reactserverrc when we get that working
+					query: {
+						babelrc: false,
+						presets: [require.resolve('babel-preset-react-server')],
+						// This is a feature of `babel-loader` for webpack (not Babel itself).
+						// It enables caching results in ./node_modules/.cache/babel-loader/
+						// directory for faster rebuilds.
+						cacheDirectory: true,
+					},
 				},
 				{
 					test: /\.css$/,

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -149,7 +149,7 @@ function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, l
 				{
 					test: /\.jsx?$/,
 					loader: "babel",
-					exclude: /node_modules\/(?!example-review-module)/,
+					exclude: /node_modules\/(?!@kununu\/example-review-module)/,
 					// FIXME: Read config from the .babelrc using the webpackConfig function in .reactserverrc when we get that working
 					query: {
 						babelrc: false,

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -149,7 +149,7 @@ function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, l
 				{
 					test: /\.jsx?$/,
 					loader: "babel",
-					exclude: /node_modules/
+					exclude: /node_modules\/(?!example-review-module)/,
 				},
 				{
 					test: /\.css$/,

--- a/packages/react-server-cli/src/compileClient.js
+++ b/packages/react-server-cli/src/compileClient.js
@@ -24,6 +24,7 @@ export default (opts = {}) => {
 	const {
 		routes,
 		webpackConfig,
+		rulesPath,
 		workingDir = "./__clientTemp",
 		routesDir = ".",
 		outputDir = workingDir + "/build",
@@ -78,7 +79,7 @@ export default (opts = {}) => {
 	writeWebpackCompatibleRoutesFile(routes, routesDir, workingDirAbsolute, null, true);
 
 	// finally, let's pack this up with webpack.
-	const compiler = webpack(webpackConfigFunc(packageCodeForBrowser(entrypoints, outputDirAbsolute, outputUrl, hot, minify, longTermCaching, stats)));
+	const compiler = webpack(webpackConfigFunc(packageCodeForBrowser(entrypoints, outputDirAbsolute, outputUrl, hot, minify, longTermCaching, stats, rulesPath)));
 
 	const serverRoutes = new Promise((resolve) => {
 		compiler.plugin("done", (stats) => {
@@ -132,9 +133,10 @@ function statsToManifest(stats) {
 	};
 }
 
-function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, longTermCaching, stats) {
+function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, longTermCaching, stats, rulesPath) {
 	const NonCachingExtractTextLoader = path.join(__dirname, "./NonCachingExtractTextLoader");
 	const extractTextLoader = require.resolve(NonCachingExtractTextLoader) + "?{remove:true}!css-loader";
+	const babelConfig = rulesPath ? JSON.parse(fs.readFileSync(path.resolve(rulesPath + '/.babelrc'))) : {};
 	let webpackConfig = {
 		entry: entrypoints,
 		output: {
@@ -152,8 +154,7 @@ function packageCodeForBrowser(entrypoints, outputDir, outputUrl, hot, minify, l
 					exclude: /node_modules\/(?!@kununu\/example-review-module)/,
 					// FIXME: Read config from the .babelrc using the webpackConfig function in .reactserverrc when we get that working
 					query: {
-						babelrc: false,
-						presets: [require.resolve('babel-preset-react-server')],
+						...babelConfig,
 						// This is a feature of `babel-loader` for webpack (not Babel itself).
 						// It enables caching results in ./node_modules/.cache/babel-loader/
 						// directory for faster rebuilds.


### PR DESCRIPTION
This was an experimental approach for integrating @kununu's example integration app with the example review module. This first version is hardcoded and hacky and was primarily a proof of concept that would need to be improved.